### PR TITLE
Federation Map: Update pointer for Karlsruher Institut für Technologie

### DIFF
--- a/static/images/federation_map.svg
+++ b/static/images/federation_map.svg
@@ -894,7 +894,7 @@
      id="path1467" /><path
      d="M 360.72381,381.097 V 59.711 h -23.13002 v -7.71 h 32.00002 v 336.807 h -32.00002 v -7.711 z"
      id="path1469" /></g><a
-   href="https://dsn.tm.kit.edu/"
+   href="https://dsn.kastel.kit.edu/"
    target="_blank"
    rel="noopener noreferrer"
    class="matrix_frame"
@@ -915,7 +915,7 @@
      id="tspan1477"
      x="3159.3354"
      y="9166.5322"
-     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:213.333px;stroke-width:10">Karlsruher Institut für Technologie (KIT)</tspan></text><g
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:213.333px;stroke-width:10">Karlsruher Institut für Technologie (KIT), DSN-Gruppe und weitere</tspan></text><g
    id="m_uni_stuttgart"
    class="matrix_icon"
    transform="translate(3551.4921,9305.5878)"><path


### PR DESCRIPTION
The DSN Group moved to KASTEL institute, and no higher-ranked installation currently exists.
However, make it explicit that other groups on the same level use Matrix as well.

We are working on an installation for either the KASTEL competence center, or even a KIT-wide instance isn't impossible in the somewhat near future. I will come and update again when either has happened. :)