### PR TITLE
Remove misleading info about rooms being deleted after last user leaves

### DIFF
--- a/content/rooms/delete.en.md
+++ b/content/rooms/delete.en.md
@@ -8,11 +8,9 @@ weight: 30
 ## Delete rooms and leave rooms
 
 
-When leaving rooms, they no longer appear in the room list (left column). If the last person in the room leaves the room, the room is still in the archive for 7 days, but is then permanently deleted.
+When leaving rooms, they no longer appear in the room list (left column).
 
 ![Room settings with the selection Leave](/images/01_Leave_en.png)
-
-As administrator, all room members should first be "kicked" (removed from the room), then the person is the last to leave the room and thus initiates the later deletion by the server.
 
 An export of the room history is possible into a .txt/.html/.json file:
 

--- a/content/rooms/delete.md
+++ b/content/rooms/delete.md
@@ -8,7 +8,7 @@ weight: 30
 ## Räume löschen und aus Räumen austreten
 
 
-Durch das Verlassen von Räumen erscheinen diese nicht mehr in der Raumliste (linke Spalte)
+Durch das Verlassen von Räumen erscheinen diese nicht mehr in der Raumliste (linke Spalte).
 
 ![Raumeinstellungen mit der Auswahl Verlassen](/images/01_Leave_de.png)
 

--- a/content/rooms/delete.md
+++ b/content/rooms/delete.md
@@ -8,11 +8,9 @@ weight: 30
 ## Räume löschen und aus Räumen austreten
 
 
-Durch das Verlassen von Räumen erscheinen diese nicht mehr in der Raumliste (linke Spalte). Wenn die letzte im Raum befindliche Person den Raum verlässt, ist der Raum noch für ungefähr 7 Tage im Archiv zu finden, wird aber anschließend endgültig gelöscht.
+Durch das Verlassen von Räumen erscheinen diese nicht mehr in der Raumliste (linke Spalte)
 
 ![Raumeinstellungen mit der Auswahl Verlassen](/images/01_Leave_de.png)
-
-Als Administrator:in sollten erst alle Raummitglieder „gekickt“ werden (aus dem Raum entfernt werden), anschließend verlässt die Person als letzte den Raum und initiiert so die spätere Löschung durch den Server.
 
 Ein Export der Raumhistorie ist als .txt-, .html- oder .json-Datei möglich:
 


### PR DESCRIPTION
Synapse does not do this. That is an open request but it has not been implemented. https://github.com/matrix-org/synapse/issues/4720

I sent a [message in May](https://matrix.to/#/!tIWQjETAJquswcgSTQ:tu-dresden.de/$nbbHykJfc8OJBeQ2R0hbvf3mgAtczsGSTXPidH5nzkc?via=tu-dresden.de&via=matrix.org&via=ungleich.ch) asking if this was a custom feature implemented by your university or if this sentence was a result of misunderstanding how Synapse works. I never got a response so I am making this PR to remove the misleading information. If this is a custom feature then please clarify that in the documentation.