### PR TITLE
Fix fachschaften.org text

### DIFF
--- a/content/first-steps/_index.en.md
+++ b/content/first-steps/_index.en.md
@@ -157,7 +157,7 @@ Explicitly for students:
 
 * [StudiChat](https://chat.studichat.de/#/welcome) (for all)
 
-* [Fachschaften](https://matrix.fachschaften.org/) (for student representatives)
+* [Fachschaften.org](https://matrix.fachschaften.org/) (for students of german speaking universities)
 
 Other European universities:
 

--- a/content/first-steps/_index.md
+++ b/content/first-steps/_index.md
@@ -156,7 +156,7 @@ Explizit für Studierende:
 
 * [StudiChat](https://chat.studichat.de/#/welcome) (für alle)
 
-* [Fachschaften](https://matrix.fachschaften.org/) (für Fachschaften)
+* [Fachschaften.org](https://matrix.fachschaften.org/) (für alle Hochschulangehörige im DACH-Raum)
 
 Weitere europäische Hochschulen:
 


### PR DESCRIPTION
Clarify that fachschaften.org is not only open to student councils, but provides web services for all students in DACH.

See also https://fachschaften.org/#faq